### PR TITLE
Add a step to build a self contained script to start FreeCAD

### DIFF
--- a/src/cycax_freecad_worker/base.sh
+++ b/src/cycax_freecad_worker/base.sh
@@ -1,0 +1,39 @@
+if [ -z "${CYCAX_SERVER}" ]
+then
+  echo "CYCAX_SERVER has to be defined."
+  echo "  Example: export CYCAX_SERVER=http://localhost:8765"
+  exit 5
+fi
+
+if [ -n "${1}" ]
+then
+  FREECADAPP=${1}
+else
+  echo "No FreeCAD specified on the command line, search in ~/Applications."
+  FREECADAPP=$(find ~/Applications -name "FreeCAD*.AppImage" | sort | tail -1)
+fi
+
+if [ ! -f "${FREECADAPP}" ]
+then
+  echo "Could not find FreeCAD AppImage."
+  FREECADAPP=$(which freecad)
+fi
+
+if [ ! -f "${FREECADAPP}" ]
+then
+  echo "Could not find FreeCAD."
+  exit 2
+else
+  echo "Using FreeCAD ${FREECADAPP}"
+fi
+
+TEMPFILE=$(mktemp -t cycax.XXXXXX.py)
+cat $0 | sed -e '1,/^##CYCAX##PYTHON##CODE##$/d' | base64 -d | xz -d > ${TEMPFILE}
+
+# Run FreeCAD
+echo
+echo "Starting FreeCAD and getting Tasks from ${CYCAX_SERVER}"
+echo "  CyCAx FreeCAD worker version ${VERSION} (${TEMPFILE})"
+${FREECADAPP} ${TEMPFILE}
+exit $?
+##CYCAX##PYTHON##CODE##

--- a/src/cycax_freecad_worker/cycax_client_freecad.py
+++ b/src/cycax_freecad_worker/cycax_client_freecad.py
@@ -587,13 +587,12 @@ def main(cycax_server_address: str):
             logging.warning("Part creation took %s seconds", time.time() - _start)
             upload_files(cycax_server_address, job, file_list)
             if task_counter < 0:
-                logging.warning(
-                    "Done enough work, I quit. Should run this with a service manager that can restart me."
-                )
+                logging.warning("Done enough work, I quit. Should run this with a service manager that can restart me.")
                 break
 
 
-if os.environ.get("PYTEST_VERSION") is not None:
+if os.environ.get("PYTEST_VERSION") is None:
+    # Not in the unit test.
     # START
     cycax_server_address = os.getenv("CYCAX_SERVER").strip("/")
     if cycax_server_address is None:


### PR DESCRIPTION
Running `make build` will create `dist/cycax-freecad-worker.sh` this is a script that will find a version of FreeCAD on the machine and start it with the Python code.

I tried to package FreeCAD in a container but it requires a custom compile of FreeCAD 1.0.0 and that is not with in the scope of work, i.e. not worth it when the AppImage works well. 